### PR TITLE
Add missing return-type annotations

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -12,10 +12,10 @@ declare class IdleQueue {
     wrapCall(fun: Function): Promise<any>;
 
     requestIdlePromise(options?: Options): Promise<void>;
-    cancelIdlePromise(prom: Promise<void>);
+    cancelIdlePromise(prom: Promise<void>): void;
 
     requestIdleCallback(cb: Function, options: Options): number;
-    cancelIdleCallback(handle: number);
+    cancelIdleCallback(handle: number): void;
 
     clear(): void;
 }


### PR DESCRIPTION
This adds missing return-type annotations for `cancelIdlePromise` and `cancelIdleCallback`, which both return `void`.