### PR TITLE
Upgrade @babel/runtime to version 7.27.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,5 @@
     "uglify-js": "3.9.3",
     "walk-sync": "0.3.3"
   },
-  "dependencies": {
-    "@babel/runtime": "7.9.6"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Adjust @babel/runtime version to ^7.27.0, fixing [GHSA-968p-4wvh-cqc8](https://github.com/advisories/GHSA-968p-4wvh-cqc8) vulnerability.

Resolves #3.